### PR TITLE
启动Kcptun前检测服务地址是否为IPv6，并做适当处理。

### DIFF
--- a/files/shadowsocksr.init
+++ b/files/shadowsocksr.init
@@ -39,7 +39,11 @@ uci_get_by_type() {
 	echo ${ret:=$3}
 }
 
-
+valid_ip6()
+{
+	result=$(echo "$1" | sed -n "s/\(\([0-9a-fA-F]\{1,4\}:\)\{7,7\}[0-9a-fA-F]\{1,4\}\|\([0-9a-fA-F]\{1,4\}:\)\{1,7\}:\|\([0-9a-fA-F]\{1,4\}:\)\{1,6\}:[
+	echo "$result"
+}
 
 gen_config_file() {
          local host=$(uci_get_by_name $1 server)
@@ -231,6 +235,8 @@ start_redir() {
     local password=$(uci_get_by_name $GLOBAL_SERVER kcp_password)
     local kcp_param=$(uci_get_by_name $GLOBAL_SERVER kcp_param)
     [ "$password" != "" ] && password="--key "${password}
+    local ip6server=$(valid_ip6 "$kcp_server")
+    [ "$ip6server" != "" ] && kcp_server="[$ip6server]"
     service_start /usr/bin/ssr-kcptun -r $kcp_server:$kcp_port -l :$server_port  $password $kcp_param 
     kcp_enable_flag=1
 	fi


### PR DESCRIPTION
修正由于 kcptun 和 ssr 处理 Ipv6 地址方式的不同引起的使用Ipv6地址问题。即：设置ssr时使用如下形式的Ipv6地址”2001::2“，而kcptun启动需要”[2001::2]“的形式。因此修正方式是检测到是Ipv6地址时，给Kcp_server地址加上”[]“